### PR TITLE
Add bilingual localization and header language switcher

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,36 +1,22 @@
 import React from 'react';
 import { Users, Target, Lightbulb, Award, TrendingUp, Heart } from 'lucide-react';
+import { useTranslations } from '../context/LanguageContext';
 
 const About = () => {
-  const values = [
-    {
-      icon: Target,
-      title: 'Foco no Cliente',
-      description: 'Cada projeto é desenvolvido pensando nas necessidades específicas do cliente e seus objetivos de negócio.'
-    },
-    {
-      icon: Lightbulb,
-      title: 'Inovação Constante',
-      description: 'Sempre buscamos as tecnologias mais recentes e melhores práticas para entregar soluções de ponta.'
-    },
-    {
-      icon: Award,
-      title: 'Qualidade Premium',
-      description: 'Não fazemos concessões quando se trata de qualidade. Cada linha de código é cuidadosamente crafted.'
-    },
-    {
-      icon: TrendingUp,
-      title: 'Resultados Mensuráveis',
-      description: 'Desenvolvemos soluções que geram impacto real e resultados tangíveis para o seu negócio.'
-    }
-  ];
+  const t = useTranslations();
+  const valuesConfig = [Target, Lightbulb, Award, TrendingUp];
+  const values = valuesConfig.map((IconComponent, index) => ({
+    icon: IconComponent,
+    title: t.about.values[index]?.title ?? '',
+    description: t.about.values[index]?.description ?? ''
+  }));
 
-  const stats = [
-    { number: '100+', label: 'Projetos Entregues', icon: Award },
-    { number: '50+', label: 'Clientes Satisfeitos', icon: Users },
-    { number: '5+', label: 'Anos de Experiência', icon: TrendingUp },
-    { number: '99%', label: 'Taxa de Satisfação', icon: Heart }
-  ];
+  const statsIcons = [Award, Users, TrendingUp, Heart];
+  const stats = statsIcons.map((IconComponent, index) => ({
+    icon: IconComponent,
+    number: t.about.stats[index]?.number ?? '',
+    label: t.about.stats[index]?.label ?? ''
+  }));
 
   return (
     <section id="sobre" className="py-24 bg-gray-50">
@@ -39,17 +25,15 @@ const About = () => {
         <div className="text-center mb-16">
           <div className="inline-flex items-center space-x-2 bg-green-100 text-green-600 px-4 py-2 rounded-full text-sm font-medium mb-4">
             <Users className="w-4 h-4" />
-            <span>Sobre Nós</span>
+            <span>{t.about.badge}</span>
           </div>
           <h2 className="text-4xl sm:text-5xl font-bold text-gray-900 mb-6">
-            Quem Somos e
+            {t.about.headingLine1}
             <span className="block bg-gradient-to-r from-green-600 to-blue-600 bg-clip-text text-transparent">
-              Nossa Missão
+              {t.about.headingHighlight}
             </span>
           </h2>
-          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-            Somos uma equipe apaixonada por tecnologia, dedicada a transformar ideias em soluções digitais que fazem a diferença
-          </p>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">{t.about.description}</p>
         </div>
 
         {/* Main Content */}
@@ -57,31 +41,18 @@ const About = () => {
           {/* Text Content */}
           <div>
             <h3 className="text-3xl font-bold text-gray-900 mb-6">
-              Transformando o Digital desde 2019
+              {t.about.timelineHeading}
             </h3>
             <div className="space-y-4 text-gray-600 leading-relaxed">
-              <p>
-                A <strong className="text-gray-900">TG Apps</strong> nasceu da paixão por criar soluções digitais que realmente importam. 
-                Começamos como uma pequena equipe de desenvolvedores e designers, e hoje somos uma empresa consolidada 
-                no mercado de desenvolvimento web e mobile.
-              </p>
-              <p>
-                Nossa jornada é marcada pela busca constante da excelência técnica e pela satisfação dos nossos clientes. 
-                Acreditamos que a tecnologia deve ser uma ferramenta para simplificar a vida das pessoas e impulsionar negócios.
-              </p>
-              <p>
-                Cada projeto é uma oportunidade de aprender, inovar e superar expectativas. Trabalhamos com metodologias 
-                ágeis, sempre mantendo a comunicação transparente e o foco nos resultados.
-              </p>
+              {t.about.paragraphs.map((paragraph, index) => (
+                <p key={index}>{paragraph}</p>
+              ))}
             </div>
 
             {/* Mission Statement */}
             <div className="mt-8 p-6 bg-gradient-to-r from-blue-50 to-purple-50 rounded-2xl border border-blue-100">
-              <h4 className="text-xl font-bold text-gray-900 mb-3">Nossa Missão</h4>
-              <p className="text-gray-700 italic">
-                "Democratizar o acesso à tecnologia de qualidade, criando soluções digitais que conectam pessoas, 
-                impulsionam negócios e transformam ideias em realidade."
-              </p>
+              <h4 className="text-xl font-bold text-gray-900 mb-3">{t.about.missionHeading}</h4>
+              <p className="text-gray-700 italic">{t.about.missionDescription}</p>
             </div>
           </div>
 
@@ -90,11 +61,11 @@ const About = () => {
             <div className="relative rounded-2xl overflow-hidden shadow-2xl">
               <img
                 src="https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=800"
-                alt="Equipe TG Apps trabalhando"
+                alt="TG Apps team collaborating"
                 className="w-full h-96 object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-blue-900/50 to-transparent"></div>
-              
+
               {/* Floating Card */}
               <div className="absolute bottom-6 left-6 right-6 bg-white/95 backdrop-blur-sm rounded-xl p-4">
                 <div className="flex items-center space-x-4">
@@ -102,8 +73,8 @@ const About = () => {
                     <Heart className="w-6 h-6 text-white" />
                   </div>
                   <div>
-                    <h5 className="font-bold text-gray-900">Paixão pelo que fazemos</h5>
-                    <p className="text-sm text-gray-600">Cada projeto é desenvolvido com dedicação e carinho</p>
+                    <h5 className="font-bold text-gray-900">{t.about.passionTitle}</h5>
+                    <p className="text-sm text-gray-600">{t.about.passionDescription}</p>
                   </div>
                 </div>
               </div>
@@ -117,7 +88,7 @@ const About = () => {
 
         {/* Values */}
         <div className="mb-20">
-          <h3 className="text-3xl font-bold text-gray-900 text-center mb-12">Nossos Valores</h3>
+          <h3 className="text-3xl font-bold text-gray-900 text-center mb-12">{t.about.valuesHeading}</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
             {values.map((value, index) => {
               const IconComponent = value.icon;
@@ -139,7 +110,7 @@ const About = () => {
 
         {/* Stats */}
         <div className="bg-white rounded-2xl p-8 shadow-lg">
-          <h3 className="text-3xl font-bold text-gray-900 text-center mb-12">Números que Falam por Si</h3>
+          <h3 className="text-3xl font-bold text-gray-900 text-center mb-12">{t.about.statsHeading}</h3>
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-8">
             {stats.map((stat, index) => {
               const IconComponent = stat.icon;

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Mail, Phone, MapPin, Send, CheckCircle, Clock, MessageSquare } from 'lucide-react';
+import { useTranslations } from '../context/LanguageContext';
 
 const Contact = () => {
   const [formData, setFormData] = useState({
@@ -12,6 +13,7 @@ const Contact = () => {
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const t = useTranslations();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     setFormData({
@@ -44,48 +46,19 @@ const Contact = () => {
     }, 3000);
   };
 
-  const contactInfo = [
-    {
-      icon: Mail,
-      title: 'Email',
-      value: 'support@tgapps.dev',
-      description: 'Resposta em até 2 horas',
-      color: 'from-blue-500 to-cyan-500'
-    },
-    {
-      icon: Phone,
-      title: 'Telefone',
-      value: '+55 (11) 99999-9999',
-      description: 'Seg-Sex, 9h às 18h',
-      color: 'from-green-500 to-emerald-500'
-    },
-    {
-      icon: MapPin,
-      title: 'Localização',
-      value: 'São Paulo, SP',
-      description: 'Atendimento remoto',
-      color: 'from-purple-500 to-pink-500'
-    }
+  const contactInfoConfig = [
+    { icon: Mail, color: 'from-blue-500 to-cyan-500' },
+    { icon: Phone, color: 'from-green-500 to-emerald-500' },
+    { icon: MapPin, color: 'from-purple-500 to-pink-500' }
   ];
 
-  const services = [
-    'Desenvolvimento Web',
-    'Aplicativo Mobile',
-    'UI/UX Design',
-    'E-commerce',
-    'Sistema Personalizado',
-    'Consultoria Técnica',
-    'Outro'
-  ];
+  const contactInfo = contactInfoConfig.map((config, index) => ({
+    ...config,
+    ...t.contact.info[index]
+  }));
 
-  const budgetRanges = [
-    'R$ 5.000 - R$ 15.000',
-    'R$ 15.000 - R$ 30.000',
-    'R$ 30.000 - R$ 50.000',
-    'R$ 50.000 - R$ 100.000',
-    'Acima de R$ 100.000',
-    'Prefiro não informar'
-  ];
+  const services = t.contact.services;
+  const budgetRanges = t.contact.budgets;
 
   return (
     <section id="contato" className="py-24 bg-white">
@@ -94,23 +67,21 @@ const Contact = () => {
         <div className="text-center mb-16">
           <div className="inline-flex items-center space-x-2 bg-orange-100 text-orange-600 px-4 py-2 rounded-full text-sm font-medium mb-4">
             <MessageSquare className="w-4 h-4" />
-            <span>Fale Conosco</span>
+            <span>{t.contact.badge}</span>
           </div>
           <h2 className="text-4xl sm:text-5xl font-bold text-gray-900 mb-6">
-            Vamos Transformar
+            {t.contact.headingLine1}
             <span className="block bg-gradient-to-r from-orange-600 to-red-600 bg-clip-text text-transparent">
-              Sua Ideia em Realidade
+              {t.contact.headingHighlight}
             </span>
           </h2>
-          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-            Estamos prontos para ouvir sua ideia e criar a solução digital perfeita para o seu negócio. Entre em contato conosco!
-          </p>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">{t.contact.description}</p>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
           {/* Contact Info */}
           <div className="lg:col-span-1">
-            <h3 className="text-2xl font-bold text-gray-900 mb-8">Como nos encontrar</h3>
+            <h3 className="text-2xl font-bold text-gray-900 mb-8">{t.contact.infoHeading}</h3>
             <div className="space-y-6">
               {contactInfo.map((info, index) => {
                 const IconComponent = info.icon;
@@ -131,24 +102,14 @@ const Contact = () => {
 
             {/* Quick Stats */}
             <div className="mt-12 p-6 bg-gradient-to-br from-blue-50 to-purple-50 rounded-2xl border border-blue-100">
-              <h4 className="font-bold text-gray-900 mb-4">Por que escolher a TG Apps?</h4>
+              <h4 className="font-bold text-gray-900 mb-4">{t.contact.whyUsHeading}</h4>
               <div className="space-y-3">
-                <div className="flex items-center space-x-3">
-                  <CheckCircle className="w-5 h-5 text-green-500" />
-                  <span className="text-gray-700 text-sm">Resposta rápida em até 2 horas</span>
-                </div>
-                <div className="flex items-center space-x-3">
-                  <CheckCircle className="w-5 h-5 text-green-500" />
-                  <span className="text-gray-700 text-sm">Orçamento gratuito e sem compromisso</span>
-                </div>
-                <div className="flex items-center space-x-3">
-                  <CheckCircle className="w-5 h-5 text-green-500" />
-                  <span className="text-gray-700 text-sm">Consultoria técnica especializada</span>
-                </div>
-                <div className="flex items-center space-x-3">
-                  <CheckCircle className="w-5 h-5 text-green-500" />
-                  <span className="text-gray-700 text-sm">Suporte contínuo pós-entrega</span>
-                </div>
+                {t.contact.whyUs.map((item, index) => (
+                  <div key={index} className="flex items-center space-x-3">
+                    <CheckCircle className="w-5 h-5 text-green-500" />
+                    <span className="text-gray-700 text-sm">{item}</span>
+                  </div>
+                ))}
               </div>
             </div>
           </div>
@@ -156,23 +117,23 @@ const Contact = () => {
           {/* Contact Form */}
           <div className="lg:col-span-2">
             <div className="bg-gray-50 rounded-2xl p-8">
-              <h3 className="text-2xl font-bold text-gray-900 mb-2">Solicite seu orçamento</h3>
-              <p className="text-gray-600 mb-8">Preencha o formulário abaixo e entraremos em contato em breve</p>
+              <h3 className="text-2xl font-bold text-gray-900 mb-2">{t.contact.formHeading}</h3>
+              <p className="text-gray-600 mb-8">{t.contact.formDescription}</p>
 
               {isSubmitted ? (
                 <div className="text-center py-12">
                   <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
                     <CheckCircle className="w-8 h-8 text-green-600" />
                   </div>
-                  <h4 className="text-xl font-bold text-gray-900 mb-2">Mensagem enviada com sucesso!</h4>
-                  <p className="text-gray-600">Entraremos em contato em breve. Obrigado!</p>
+                  <h4 className="text-xl font-bold text-gray-900 mb-2">{t.contact.successTitle}</h4>
+                  <p className="text-gray-600">{t.contact.successMessage}</p>
                 </div>
               ) : (
                 <form onSubmit={handleSubmit} className="space-y-6">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div>
                       <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
-                        Nome completo *
+                        {t.contact.form.nameLabel}
                       </label>
                       <input
                         type="text"
@@ -182,12 +143,12 @@ const Contact = () => {
                         value={formData.name}
                         onChange={handleChange}
                         className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                        placeholder="Seu nome completo"
+                        placeholder={t.contact.form.namePlaceholder}
                       />
                     </div>
                     <div>
                       <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
-                        Email *
+                        {t.contact.form.emailLabel}
                       </label>
                       <input
                         type="email"
@@ -197,7 +158,7 @@ const Contact = () => {
                         value={formData.email}
                         onChange={handleChange}
                         className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                        placeholder="seu@email.com"
+                        placeholder={t.contact.form.emailPlaceholder}
                       />
                     </div>
                   </div>
@@ -205,7 +166,7 @@ const Contact = () => {
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div>
                       <label htmlFor="phone" className="block text-sm font-medium text-gray-700 mb-2">
-                        Telefone
+                        {t.contact.form.phoneLabel}
                       </label>
                       <input
                         type="tel"
@@ -214,12 +175,12 @@ const Contact = () => {
                         value={formData.phone}
                         onChange={handleChange}
                         className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-                        placeholder="(11) 99999-9999"
+                        placeholder={t.contact.form.phonePlaceholder}
                       />
                     </div>
                     <div>
                       <label htmlFor="service" className="block text-sm font-medium text-gray-700 mb-2">
-                        Tipo de serviço *
+                        {t.contact.form.serviceLabel}
                       </label>
                       <select
                         id="service"
@@ -229,7 +190,7 @@ const Contact = () => {
                         onChange={handleChange}
                         className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
                       >
-                        <option value="">Selecione um serviço</option>
+                        <option value="">{t.contact.form.servicePlaceholder}</option>
                         {services.map((service, index) => (
                           <option key={index} value={service}>{service}</option>
                         ))}
@@ -239,7 +200,7 @@ const Contact = () => {
 
                   <div>
                     <label htmlFor="budget" className="block text-sm font-medium text-gray-700 mb-2">
-                      Orçamento estimado
+                      {t.contact.form.budgetLabel}
                     </label>
                     <select
                       id="budget"
@@ -248,7 +209,7 @@ const Contact = () => {
                       onChange={handleChange}
                       className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
                     >
-                      <option value="">Selecione uma faixa</option>
+                      <option value="">{t.contact.form.budgetPlaceholder}</option>
                       {budgetRanges.map((range, index) => (
                         <option key={index} value={range}>{range}</option>
                       ))}
@@ -257,7 +218,7 @@ const Contact = () => {
 
                   <div>
                     <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-2">
-                      Descreva seu projeto *
+                      {t.contact.form.messageLabel}
                     </label>
                     <textarea
                       id="message"
@@ -267,7 +228,7 @@ const Contact = () => {
                       value={formData.message}
                       onChange={handleChange}
                       className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors resize-none"
-                      placeholder="Conte-nos mais sobre seu projeto, objetivos e expectativas..."
+                      placeholder={t.contact.form.messagePlaceholder}
                     ></textarea>
                   </div>
 
@@ -279,19 +240,17 @@ const Contact = () => {
                     {isSubmitting ? (
                       <>
                         <Clock className="w-5 h-5 animate-spin" />
-                        <span>Enviando...</span>
+                        <span>{t.contact.form.submitting}</span>
                       </>
                     ) : (
                       <>
                         <Send className="w-5 h-5" />
-                        <span>Enviar Mensagem</span>
+                        <span>{t.contact.form.submit}</span>
                       </>
                     )}
                   </button>
 
-                  <p className="text-xs text-gray-500 text-center">
-                    Ao enviar este formulário, você concorda com nossa política de privacidade e termos de uso.
-                  </p>
+                  <p className="text-xs text-gray-500 text-center">{t.contact.form.policy}</p>
                 </form>
               )}
             </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Code, Smartphone, Mail, Phone, MapPin, Github, Linkedin, Instagram, ArrowUp } from 'lucide-react';
+import { useTranslations } from '../context/LanguageContext';
 
 const Footer = () => {
   const scrollToTop = () => {
@@ -14,6 +15,8 @@ const Footer = () => {
   };
 
   const currentYear = new Date().getFullYear();
+  const t = useTranslations();
+  const copyright = t.footer.bottom.copyright.replace('{year}', currentYear.toString());
 
   return (
     <footer className="bg-gray-900 text-white">
@@ -34,7 +37,7 @@ const Footer = () => {
               <span className="text-xl font-bold">TG Apps</span>
             </div>
             <p className="text-gray-400 mb-6 leading-relaxed">
-              Transformamos ideias em soluções digitais excepcionais. Especializados em desenvolvimento web e mobile com foco na experiência do usuário.
+              {t.footer.description}
             </p>
             <div className="flex space-x-4">
               <a
@@ -60,15 +63,9 @@ const Footer = () => {
 
           {/* Quick Links */}
           <div>
-            <h3 className="text-lg font-semibold mb-6">Navegação</h3>
+            <h3 className="text-lg font-semibold mb-6">{t.footer.navigationHeading}</h3>
             <ul className="space-y-3">
-              {[
-                { label: 'Início', id: 'inicio' },
-                { label: 'Serviços', id: 'servicos' },
-                { label: 'Portfólio', id: 'portfolio' },
-                { label: 'Sobre Nós', id: 'sobre' },
-                { label: 'Contato', id: 'contato' }
-              ].map((link) => (
+              {t.footer.navigation.map((link) => (
                 <li key={link.id}>
                   <button
                     onClick={() => scrollToSection(link.id)}
@@ -83,16 +80,9 @@ const Footer = () => {
 
           {/* Services */}
           <div>
-            <h3 className="text-lg font-semibold mb-6">Serviços</h3>
+            <h3 className="text-lg font-semibold mb-6">{t.footer.servicesHeading}</h3>
             <ul className="space-y-3">
-              {[
-                'Desenvolvimento Web',
-                'Apps Mobile',
-                'UI/UX Design',
-                'E-commerce',
-                'Sistemas Personalizados',
-                'Consultoria Técnica'
-              ].map((service) => (
+              {t.footer.services.map((service) => (
                 <li key={service}>
                   <span className="text-gray-400 hover:text-white transition-colors cursor-pointer">
                     {service}
@@ -104,7 +94,7 @@ const Footer = () => {
 
           {/* Contact Info */}
           <div>
-            <h3 className="text-lg font-semibold mb-6">Contato</h3>
+            <h3 className="text-lg font-semibold mb-6">{t.footer.contactHeading}</h3>
             <div className="space-y-4">
               <div className="flex items-center space-x-3">
                 <Mail className="w-5 h-5 text-blue-400 flex-shrink-0" />
@@ -112,7 +102,7 @@ const Footer = () => {
                   href="mailto:support@tgapps.dev"
                   className="text-gray-400 hover:text-white transition-colors"
                 >
-                  support@tgapps.dev
+                  {t.footer.contact.emailLabel}
                 </a>
               </div>
               <div className="flex items-center space-x-3">
@@ -121,12 +111,12 @@ const Footer = () => {
                   href="tel:+5511999999999"
                   className="text-gray-400 hover:text-white transition-colors"
                 >
-                  +55 (11) 99999-9999
+                  {t.footer.contact.phoneLabel}
                 </a>
               </div>
               <div className="flex items-center space-x-3">
                 <MapPin className="w-5 h-5 text-purple-400 flex-shrink-0" />
-                <span className="text-gray-400">São Paulo, SP</span>
+                <span className="text-gray-400">{t.footer.contact.location}</span>
               </div>
             </div>
 
@@ -136,7 +126,7 @@ const Footer = () => {
                 onClick={() => scrollToSection('contato')}
                 className="bg-gradient-to-r from-blue-600 to-purple-600 text-white px-6 py-3 rounded-lg font-medium hover:shadow-lg transition-all duration-300 hover:scale-105"
               >
-                Solicitar Orçamento
+                {t.footer.cta}
               </button>
             </div>
           </div>
@@ -147,16 +137,14 @@ const Footer = () => {
       <div className="border-t border-gray-800">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex flex-col md:flex-row justify-between items-center">
-            <div className="text-gray-400 text-sm mb-4 md:mb-0">
-              © {currentYear} TG Apps. Todos os direitos reservados.
-            </div>
-            
+            <div className="text-gray-400 text-sm mb-4 md:mb-0">{copyright}</div>
+
             <div className="flex items-center space-x-6">
               <a href="#" className="text-gray-400 hover:text-white text-sm transition-colors">
-                Política de Privacidade
+                {t.footer.bottom.privacy}
               </a>
               <a href="#" className="text-gray-400 hover:text-white text-sm transition-colors">
-                Termos de Uso
+                {t.footer.bottom.terms}
               </a>
               <button
                 onClick={scrollToTop}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,13 @@
 import React, { useState, useEffect } from 'react';
-import { Menu, X, Code, Smartphone } from 'lucide-react';
+import { Menu, X, Code, Smartphone, Check } from 'lucide-react';
+import type { Locale } from '../i18n/translations';
+import { useLanguage, useTranslations } from '../context/LanguageContext';
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const { language, setLanguage } = useLanguage();
+  const t = useTranslations();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -20,6 +24,46 @@ const Header = () => {
       setIsMenuOpen(false);
     }
   };
+
+  const languageOptions: { code: Locale; flag: string; label: string }[] = [
+    { code: 'en', flag: '🇺🇸', label: 'English' },
+    { code: 'pt', flag: '🇧🇷', label: 'Português' }
+  ];
+
+  const renderLanguageSwitcher = (variant: 'desktop' | 'mobile') => (
+    <div
+      className={`flex items-center gap-2 ${
+        variant === 'desktop'
+          ? isScrolled
+            ? 'bg-gray-100 border border-gray-200'
+            : 'bg-white/10 border border-white/20 backdrop-blur-sm'
+          : 'bg-gray-100 border border-gray-200'
+      } rounded-full px-2 py-1`}
+    >
+      {languageOptions.map((option) => (
+        <button
+          key={option.code}
+          type="button"
+          onClick={() => setLanguage(option.code)}
+          className={`relative flex h-8 w-8 items-center justify-center rounded-full text-lg transition-colors ${
+            language === option.code
+              ? 'bg-white shadow-md'
+              : variant === 'desktop' && !isScrolled
+                ? 'text-white/80 hover:bg-white/10'
+                : 'text-gray-600 hover:bg-white'
+          }`}
+          aria-label={option.label}
+        >
+          <span>{option.flag}</span>
+          {language === option.code && (
+            <span className="absolute -bottom-1 right-0 flex h-4 w-4 items-center justify-center rounded-full bg-blue-600 text-white">
+              <Check className="h-3 w-3" />
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
 
   return (
     <header className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
@@ -46,22 +90,23 @@ const Header = () => {
 
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center space-x-8">
-            {['Início', 'Serviços', 'Portfólio', 'Sobre', 'Contato'].map((item) => (
+            {t.header.navItems.map((item) => (
               <button
-                key={item}
-                onClick={() => scrollToSection(item.toLowerCase().replace('í', 'i').replace('ó', 'o'))}
+                key={item.id}
+                onClick={() => scrollToSection(item.id)}
                 className={`text-sm font-medium transition-colors hover:text-blue-500 ${
                   isScrolled ? 'text-gray-700' : 'text-white/90'
                 }`}
               >
-                {item}
+                {item.label}
               </button>
             ))}
+            {renderLanguageSwitcher('desktop')}
             <button
-              onClick={() => scrollToSection('contato')}
+              onClick={() => scrollToSection(t.header.contactId)}
               className="bg-gradient-to-r from-blue-500 to-purple-600 text-white px-6 py-2 rounded-full text-sm font-medium hover:shadow-lg transition-all duration-300 hover:scale-105"
             >
-              Fale Conosco
+              {t.header.contactCta}
             </button>
           </nav>
 
@@ -80,20 +125,21 @@ const Header = () => {
         {isMenuOpen && (
           <div className="md:hidden absolute top-16 left-0 right-0 bg-white shadow-xl rounded-b-2xl border-t">
             <nav className="px-4 py-6 space-y-4">
-              {['Início', 'Serviços', 'Portfólio', 'Sobre', 'Contato'].map((item) => (
+              {t.header.navItems.map((item) => (
                 <button
-                  key={item}
-                  onClick={() => scrollToSection(item.toLowerCase().replace('í', 'i').replace('ó', 'o'))}
+                  key={item.id}
+                  onClick={() => scrollToSection(item.id)}
                   className="block w-full text-left text-gray-700 font-medium py-2 hover:text-blue-500 transition-colors"
                 >
-                  {item}
+                  {item.label}
                 </button>
               ))}
+              <div className="pt-2">{renderLanguageSwitcher('mobile')}</div>
               <button
-                onClick={() => scrollToSection('contato')}
+                onClick={() => scrollToSection(t.header.contactId)}
                 className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white px-6 py-3 rounded-full font-medium hover:shadow-lg transition-all duration-300"
               >
-                Fale Conosco
+                {t.header.contactCta}
               </button>
             </nav>
           </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 import { ArrowRight, Play, Star, Users, Award, Zap } from 'lucide-react';
+import { useTranslations } from '../context/LanguageContext';
 
 const Hero = () => {
+  const t = useTranslations();
   const scrollToSection = (sectionId: string) => {
     const element = document.getElementById(sectionId);
     if (element) {
       element.scrollIntoView({ behavior: 'smooth' });
     }
   };
+
+  const statsIcons = [Users, Award, Zap];
+  const stats = statsIcons.map((IconComponent, index) => ({
+    IconComponent,
+    label: t.hero.stats[index]?.label ?? ''
+  }));
 
   return (
     <section id="inicio" className="relative min-h-screen flex items-center justify-center overflow-hidden">
@@ -28,37 +36,33 @@ const Hero = () => {
           {/* Badge */}
           <div className="inline-flex items-center space-x-2 bg-white/10 backdrop-blur-md rounded-full px-4 py-2 mb-8 border border-white/20">
             <Star className="w-4 h-4 text-yellow-400" />
-            <span className="text-white/90 text-sm font-medium">Especialistas em Desenvolvimento Digital</span>
+            <span className="text-white/90 text-sm font-medium">{t.hero.badge}</span>
           </div>
 
           {/* Main heading */}
           <h1 className="text-4xl sm:text-5xl lg:text-7xl font-bold text-white mb-6 leading-tight">
-            Transformamos
+            {t.hero.titleLine1}
             <span className="block bg-gradient-to-r from-blue-400 via-purple-400 to-pink-400 bg-clip-text text-transparent">
-              Ideias em Realidade
+              {t.hero.titleHighlight}
             </span>
-            Digital
+            {t.hero.titleLine2}
           </h1>
 
           {/* Subtitle */}
-          <p className="text-xl sm:text-2xl text-white/80 mb-8 max-w-3xl mx-auto leading-relaxed">
-            Criamos <strong>sites modernos</strong> e <strong>aplicativos mobile</strong> que impulsionam seu negócio para o próximo nível
-          </p>
+          <p className="text-xl sm:text-2xl text-white/80 mb-8 max-w-3xl mx-auto leading-relaxed">{t.hero.subtitle}</p>
 
           {/* Stats */}
           <div className="flex flex-wrap justify-center items-center gap-8 mb-12">
-            <div className="flex items-center space-x-2 text-white/90">
-              <Users className="w-5 h-5 text-blue-400" />
-              <span className="font-semibold">100+ Clientes</span>
-            </div>
-            <div className="flex items-center space-x-2 text-white/90">
-              <Award className="w-5 h-5 text-purple-400" />
-              <span className="font-semibold">200+ Projetos</span>
-            </div>
-            <div className="flex items-center space-x-2 text-white/90">
-              <Zap className="w-5 h-5 text-pink-400" />
-              <span className="font-semibold">5 Anos de Experiência</span>
-            </div>
+            {stats.map(({ IconComponent, label }, index) => (
+              <div key={index} className="flex items-center space-x-2 text-white/90">
+                <IconComponent
+                  className={`w-5 h-5 ${
+                    index === 0 ? 'text-blue-400' : index === 1 ? 'text-purple-400' : 'text-pink-400'
+                  }`}
+                />
+                <span className="font-semibold">{label}</span>
+              </div>
+            ))}
           </div>
 
           {/* CTA Buttons */}
@@ -67,16 +71,16 @@ const Hero = () => {
               onClick={() => scrollToSection('contato')}
               className="group bg-gradient-to-r from-blue-500 to-purple-600 text-white px-8 py-4 rounded-full font-semibold text-lg hover:shadow-2xl transition-all duration-300 hover:scale-105 flex items-center space-x-2"
             >
-              <span>Começar Projeto</span>
+              <span>{t.hero.primaryCta}</span>
               <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
             </button>
-            
+
             <button
               onClick={() => scrollToSection('portfolio')}
               className="group bg-white/10 backdrop-blur-md text-white px-8 py-4 rounded-full font-semibold text-lg hover:bg-white/20 transition-all duration-300 border border-white/20 flex items-center space-x-2"
             >
               <Play className="w-5 h-5" />
-              <span>Ver Portfólio</span>
+              <span>{t.hero.secondaryCta}</span>
             </button>
           </div>
 

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -1,80 +1,80 @@
 import React, { useState } from 'react';
 import { ExternalLink, Github, Smartphone, Globe, ArrowRight, Filter } from 'lucide-react';
+import { useTranslations } from '../context/LanguageContext';
 
 const Portfolio = () => {
   const [activeFilter, setActiveFilter] = useState('all');
+  const t = useTranslations();
 
-  const projects = [
+  const baseProjects = [
     {
       id: 1,
-      title: 'E-commerce Fashion',
       category: 'web',
-      description: 'Plataforma completa de e-commerce com sistema de pagamento integrado e painel administrativo.',
       image: 'https://images.pexels.com/photos/230544/pexels-photo-230544.jpeg?auto=compress&cs=tinysrgb&w=800',
       technologies: ['React', 'Node.js', 'MongoDB', 'Stripe'],
-      type: 'Website',
-      status: 'Concluído'
+      translationIndex: 0
     },
     {
       id: 2,
-      title: 'App Delivery Food',
       category: 'mobile',
-      description: 'Aplicativo de delivery com geolocalização, pagamento online e sistema de avaliações.',
       image: 'https://images.pexels.com/photos/1640777/pexels-photo-1640777.jpeg?auto=compress&cs=tinysrgb&w=800',
       technologies: ['React Native', 'Firebase', 'Maps API', 'PayPal'],
-      type: 'Mobile App',
-      status: 'Concluído'
+      translationIndex: 1
     },
     {
       id: 3,
-      title: 'Dashboard Analytics',
       category: 'web',
-      description: 'Painel de controle com visualização de dados em tempo real e relatórios personalizados.',
       image: 'https://images.pexels.com/photos/590022/pexels-photo-590022.jpeg?auto=compress&cs=tinysrgb&w=800',
       technologies: ['Vue.js', 'D3.js', 'Python', 'PostgreSQL'],
-      type: 'Web App',
-      status: 'Concluído'
+      translationIndex: 2
     },
     {
       id: 4,
-      title: 'App Fitness Tracker',
       category: 'mobile',
-      description: 'Aplicativo de acompanhamento fitness com integração de wearables e planos personalizados.',
       image: 'https://images.pexels.com/photos/841130/pexels-photo-841130.jpeg?auto=compress&cs=tinysrgb&w=800',
       technologies: ['Flutter', 'HealthKit', 'Firebase', 'ML Kit'],
-      type: 'Mobile App',
-      status: 'Em desenvolvimento'
+      translationIndex: 3
     },
     {
       id: 5,
-      title: 'Portal Educacional',
       category: 'web',
-      description: 'Plataforma de ensino online com videoaulas, exercícios interativos e sistema de certificação.',
       image: 'https://images.pexels.com/photos/159711/books-bookstore-book-reading-159711.jpeg?auto=compress&cs=tinysrgb&w=800',
       technologies: ['Next.js', 'Prisma', 'AWS', 'WebRTC'],
-      type: 'Website',
-      status: 'Concluído'
+      translationIndex: 4
     },
     {
       id: 6,
-      title: 'App Banking',
       category: 'mobile',
-      description: 'Aplicativo bancário com autenticação biométrica, transferências e investimentos.',
       image: 'https://images.pexels.com/photos/259200/pexels-photo-259200.jpeg?auto=compress&cs=tinysrgb&w=800',
       technologies: ['React Native', 'Biometrics', 'Encryption', 'APIs'],
-      type: 'Mobile App',
-      status: 'Em desenvolvimento'
+      translationIndex: 5
     }
   ];
 
-  const filters = [
-    { id: 'all', label: 'Todos os Projetos', count: projects.length },
-    { id: 'web', label: 'Websites', count: projects.filter(p => p.category === 'web').length },
-    { id: 'mobile', label: 'Apps Mobile', count: projects.filter(p => p.category === 'mobile').length }
-  ];
+  const projects = baseProjects.map((project) => {
+    const translation = t.portfolio.projects[project.translationIndex];
+    const statusKey = translation?.status ?? 'done';
+    return {
+      ...project,
+      title: translation?.title ?? '',
+      description: translation?.description ?? '',
+      type: translation?.type ?? '',
+      statusKey,
+      statusLabel:
+        statusKey === 'inProgress' ? t.portfolio.statusLabel.inProgress : t.portfolio.statusLabel.done
+    };
+  });
 
-  const filteredProjects = activeFilter === 'all' 
-    ? projects 
+  const filters = t.portfolio.filters.map((filter) => ({
+    ...filter,
+    count:
+      filter.id === 'all'
+        ? projects.length
+        : projects.filter((project) => project.category === filter.id).length
+  }));
+
+  const filteredProjects = activeFilter === 'all'
+    ? projects
     : projects.filter(project => project.category === activeFilter);
 
   return (
@@ -84,17 +84,15 @@ const Portfolio = () => {
         <div className="text-center mb-16">
           <div className="inline-flex items-center space-x-2 bg-purple-100 text-purple-600 px-4 py-2 rounded-full text-sm font-medium mb-4">
             <Filter className="w-4 h-4" />
-            <span>Nosso Portfólio</span>
+            <span>{t.portfolio.badge}</span>
           </div>
           <h2 className="text-4xl sm:text-5xl font-bold text-gray-900 mb-6">
-            Projetos que
+            {t.portfolio.headingLine1}
             <span className="block bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
-              Fazem a Diferença
+              {t.portfolio.headingHighlight}
             </span>
           </h2>
-          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-            Cada projeto é uma oportunidade de criar algo extraordinário. Veja alguns dos nossos trabalhos mais recentes
-          </p>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">{t.portfolio.description}</p>
         </div>
 
         {/* Filters */}
@@ -131,13 +129,13 @@ const Portfolio = () => {
                 <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                 
                 {/* Status Badge */}
-                <div className="absolute top-4 left-4">
+            <div className="absolute top-4 left-4">
                   <span className={`px-3 py-1 rounded-full text-xs font-medium ${
-                    project.status === 'Concluído' 
-                      ? 'bg-green-100 text-green-600' 
+                    project.statusKey === 'done'
+                      ? 'bg-green-100 text-green-600'
                       : 'bg-yellow-100 text-yellow-600'
                   }`}>
-                    {project.status}
+                    {project.statusLabel}
                   </span>
                 </div>
 
@@ -188,7 +186,7 @@ const Portfolio = () => {
 
                 {/* CTA */}
                 <button className="group/btn flex items-center text-purple-600 font-semibold hover:text-purple-700 transition-colors">
-                  <span>Ver detalhes</span>
+                  <span>{t.portfolio.projectCta}</span>
                   <ArrowRight className="w-4 h-4 ml-2 group-hover/btn:translate-x-1 transition-transform" />
                 </button>
               </div>
@@ -199,10 +197,8 @@ const Portfolio = () => {
         {/* Bottom CTA */}
         <div className="text-center mt-16">
           <div className="bg-gray-50 rounded-2xl p-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-4">Gostou do que viu?</h3>
-            <p className="text-gray-600 mb-6 max-w-2xl mx-auto">
-              Estes são apenas alguns exemplos do nosso trabalho. Temos muito mais para mostrar e estamos prontos para criar algo incrível para você também.
-            </p>
+            <h3 className="text-2xl font-bold text-gray-900 mb-4">{t.portfolio.bottomCta.title}</h3>
+            <p className="text-gray-600 mb-6 max-w-2xl mx-auto">{t.portfolio.bottomCta.description}</p>
             <button
               onClick={() => {
                 const element = document.getElementById('contato');
@@ -210,7 +206,7 @@ const Portfolio = () => {
               }}
               className="bg-gradient-to-r from-purple-600 to-pink-600 text-white px-8 py-3 rounded-full font-semibold hover:shadow-lg transition-all duration-300 hover:scale-105"
             >
-              Vamos Conversar
+              {t.portfolio.bottomCta.button}
             </button>
           </div>
         </div>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,63 +1,52 @@
 import React from 'react';
 import { Globe, Smartphone, Palette, Code, Zap, Shield, ArrowRight } from 'lucide-react';
+import { useTranslations } from '../context/LanguageContext';
 
 const Services = () => {
-  const services = [
+  const t = useTranslations();
+  const serviceConfigs = [
     {
       icon: Globe,
-      title: 'Desenvolvimento Web',
-      description: 'Sites modernos, responsivos e otimizados para conversão. Utilizamos as mais recentes tecnologias para criar experiências web excepcionais.',
-      features: ['React & Next.js', 'Design Responsivo', 'SEO Otimizado', 'Performance Máxima'],
       color: 'from-blue-500 to-cyan-500',
       bgColor: 'bg-blue-50',
       iconColor: 'text-blue-600'
     },
     {
       icon: Smartphone,
-      title: 'Apps Mobile',
-      description: 'Aplicativos nativos e híbridos para iOS e Android. Desenvolvemos soluções mobile que conectam sua marca aos usuários.',
-      features: ['React Native', 'iOS & Android', 'UI/UX Nativo', 'Integração APIs'],
       color: 'from-purple-500 to-pink-500',
       bgColor: 'bg-purple-50',
       iconColor: 'text-purple-600'
     },
     {
       icon: Palette,
-      title: 'UI/UX Design',
-      description: 'Interfaces intuitivas e experiências memoráveis. Criamos designs que encantam usuários e geram resultados.',
-      features: ['Design System', 'Prototipagem', 'Testes Usabilidade', 'Branding Digital'],
       color: 'from-pink-500 to-rose-500',
       bgColor: 'bg-pink-50',
       iconColor: 'text-pink-600'
     },
     {
       icon: Code,
-      title: 'Desenvolvimento Backend',
-      description: 'APIs robustas e escaláveis. Construímos a infraestrutura que sustenta suas aplicações com segurança e performance.',
-      features: ['Node.js & Python', 'APIs RESTful', 'Banco de Dados', 'Cloud Deploy'],
       color: 'from-green-500 to-emerald-500',
       bgColor: 'bg-green-50',
       iconColor: 'text-green-600'
     },
     {
       icon: Zap,
-      title: 'Otimização & Performance',
-      description: 'Maximizamos a velocidade e eficiência das suas aplicações. Cada milissegundo importa para a experiência do usuário.',
-      features: ['Core Web Vitals', 'Lazy Loading', 'Cache Strategy', 'CDN Setup'],
       color: 'from-yellow-500 to-orange-500',
       bgColor: 'bg-yellow-50',
       iconColor: 'text-yellow-600'
     },
     {
       icon: Shield,
-      title: 'Segurança & Manutenção',
-      description: 'Protegemos suas aplicações e mantemos tudo funcionando perfeitamente. Suporte contínuo e atualizações regulares.',
-      features: ['SSL & HTTPS', 'Backup Automático', 'Monitoramento 24/7', 'Suporte Técnico'],
       color: 'from-indigo-500 to-blue-500',
       bgColor: 'bg-indigo-50',
       iconColor: 'text-indigo-600'
     }
   ];
+
+  const services = serviceConfigs.map((config, index) => ({
+    ...config,
+    ...t.services.items[index]
+  }));
 
   return (
     <section id="servicos" className="py-24 bg-gray-50">
@@ -66,17 +55,15 @@ const Services = () => {
         <div className="text-center mb-16">
           <div className="inline-flex items-center space-x-2 bg-blue-100 text-blue-600 px-4 py-2 rounded-full text-sm font-medium mb-4">
             <Zap className="w-4 h-4" />
-            <span>Nossos Serviços</span>
+            <span>{t.services.badge}</span>
           </div>
           <h2 className="text-4xl sm:text-5xl font-bold text-gray-900 mb-6">
-            Soluções Completas para
+            {t.services.headingLine1}
             <span className="block bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-              Seu Sucesso Digital
+              {t.services.headingHighlight}
             </span>
           </h2>
-          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-            Oferecemos um ecossistema completo de serviços digitais, desde o conceito inicial até o lançamento e manutenção contínua
-          </p>
+          <p className="text-xl text-gray-600 max-w-3xl mx-auto">{t.services.description}</p>
         </div>
 
         {/* Services Grid */}
@@ -113,7 +100,7 @@ const Services = () => {
 
                 {/* CTA */}
                 <button className="group/btn flex items-center text-blue-600 font-semibold hover:text-blue-700 transition-colors">
-                  <span>Saiba mais</span>
+                  <span>{service.cta}</span>
                   <ArrowRight className="w-4 h-4 ml-2 group-hover/btn:translate-x-1 transition-transform" />
                 </button>
               </div>
@@ -124,10 +111,8 @@ const Services = () => {
         {/* Bottom CTA */}
         <div className="text-center mt-16">
           <div className="bg-gradient-to-r from-blue-600 to-purple-600 rounded-2xl p-8 text-white">
-            <h3 className="text-2xl font-bold mb-4">Pronto para começar seu projeto?</h3>
-            <p className="text-blue-100 mb-6 max-w-2xl mx-auto">
-              Entre em contato conosco e descubra como podemos transformar sua ideia em uma solução digital de sucesso
-            </p>
+            <h3 className="text-2xl font-bold mb-4">{t.services.bottomCta.title}</h3>
+            <p className="text-blue-100 mb-6 max-w-2xl mx-auto">{t.services.bottomCta.description}</p>
             <button
               onClick={() => {
                 const element = document.getElementById('contato');
@@ -135,7 +120,7 @@ const Services = () => {
               }}
               className="bg-white text-blue-600 px-8 py-3 rounded-full font-semibold hover:shadow-lg transition-all duration-300 hover:scale-105"
             >
-              Solicitar Orçamento
+              {t.services.bottomCta.button}
             </button>
           </div>
         </div>

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,0 +1,45 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+import type { Locale, TranslationSchema } from '../i18n/translations';
+import { translations } from '../i18n/translations';
+
+interface LanguageContextValue {
+  language: Locale;
+  setLanguage: (language: Locale) => void;
+  t: TranslationSchema;
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+interface LanguageProviderProps {
+  children: React.ReactNode;
+}
+
+export const LanguageProvider: React.FC<LanguageProviderProps> = ({ children }) => {
+  const [language, setLanguage] = useState<Locale>('en');
+
+  const value = useMemo(
+    () => ({
+      language,
+      setLanguage,
+      t: translations[language]
+    }),
+    [language]
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+};
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+
+  return context;
+};
+
+export const useTranslations = () => {
+  const { t } = useLanguage();
+  return t;
+};

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1,0 +1,708 @@
+export type Locale = 'en' | 'pt';
+
+export interface NavigationItem {
+  id: string;
+  label: string;
+}
+
+export interface TranslationSchema {
+  header: {
+    navItems: NavigationItem[];
+    contactCta: string;
+    contactId: string;
+    languageLabel: string;
+  };
+  hero: {
+    badge: string;
+    titleLine1: string;
+    titleHighlight: string;
+    titleLine2: string;
+    subtitle: string;
+    stats: { label: string }[];
+    primaryCta: string;
+    secondaryCta: string;
+  };
+  services: {
+    badge: string;
+    headingLine1: string;
+    headingHighlight: string;
+    description: string;
+    items: {
+      title: string;
+      description: string;
+      features: string[];
+      cta: string;
+    }[];
+    bottomCta: {
+      title: string;
+      description: string;
+      button: string;
+    };
+  };
+  portfolio: {
+    badge: string;
+    headingLine1: string;
+    headingHighlight: string;
+    description: string;
+    filters: { id: string; label: string }[];
+    projects: {
+      title: string;
+      description: string;
+      type: string;
+      status: string;
+    }[];
+    statusLabel: {
+      done: string;
+      inProgress: string;
+    };
+    projectCta: string;
+    bottomCta: {
+      title: string;
+      description: string;
+      button: string;
+    };
+  };
+  about: {
+    badge: string;
+    headingLine1: string;
+    headingHighlight: string;
+    description: string;
+    timelineHeading: string;
+    paragraphs: string[];
+    missionHeading: string;
+    missionDescription: string;
+    valuesHeading: string;
+    values: {
+      title: string;
+      description: string;
+    }[];
+    statsHeading: string;
+    stats: {
+      number: string;
+      label: string;
+    }[];
+    passionTitle: string;
+    passionDescription: string;
+  };
+  contact: {
+    badge: string;
+    headingLine1: string;
+    headingHighlight: string;
+    description: string;
+    infoHeading: string;
+    info: {
+      title: string;
+      value: string;
+      description: string;
+    }[];
+    whyUsHeading: string;
+    whyUs: string[];
+    formHeading: string;
+    formDescription: string;
+    successTitle: string;
+    successMessage: string;
+    form: {
+      nameLabel: string;
+      namePlaceholder: string;
+      emailLabel: string;
+      emailPlaceholder: string;
+      phoneLabel: string;
+      phonePlaceholder: string;
+      serviceLabel: string;
+      servicePlaceholder: string;
+      budgetLabel: string;
+      budgetPlaceholder: string;
+      messageLabel: string;
+      messagePlaceholder: string;
+      submit: string;
+      submitting: string;
+      policy: string;
+    };
+    services: string[];
+    budgets: string[];
+  };
+  footer: {
+    description: string;
+    navigationHeading: string;
+    navigation: NavigationItem[];
+    servicesHeading: string;
+    services: string[];
+    contactHeading: string;
+    contact: {
+      emailLabel: string;
+      phoneLabel: string;
+      location: string;
+    };
+    cta: string;
+    bottom: {
+      copyright: string;
+      privacy: string;
+      terms: string;
+    };
+  };
+}
+
+export const translations: Record<Locale, TranslationSchema> = {
+  en: {
+    header: {
+      navItems: [
+        { id: 'inicio', label: 'Home' },
+        { id: 'servicos', label: 'Services' },
+        { id: 'portfolio', label: 'Portfolio' },
+        { id: 'sobre', label: 'About' },
+        { id: 'contato', label: 'Contact' }
+      ],
+      contactCta: 'Talk to Us',
+      contactId: 'contato',
+      languageLabel: 'Language'
+    },
+    hero: {
+      badge: 'Digital Product Experts',
+      titleLine1: 'We turn',
+      titleHighlight: 'Ideas into Reality',
+      titleLine2: 'Online',
+      subtitle:
+        'We build modern websites and mobile apps that push your business to the next level and delight your customers.',
+      stats: [
+        { label: '100+ Clients' },
+        { label: '200+ Projects' },
+        { label: '5 Years of Experience' }
+      ],
+      primaryCta: 'Start a Project',
+      secondaryCta: 'View Portfolio'
+    },
+    services: {
+      badge: 'Our Services',
+      headingLine1: 'End-to-end solutions for',
+      headingHighlight: 'Your Digital Success',
+      description:
+        'We offer a full ecosystem of digital services—from the first idea to launch and long-term evolution.',
+      items: [
+        {
+          title: 'Web Development',
+          description:
+            'Modern, responsive, conversion-focused websites built with the latest technologies and performance best practices.',
+          features: ['React & Next.js', 'Responsive Design', 'SEO Optimization', 'Top-tier Performance'],
+          cta: 'Learn more'
+        },
+        {
+          title: 'Mobile Apps',
+          description:
+            'Native and cross-platform apps for iOS and Android that connect your brand with users wherever they are.',
+          features: ['React Native', 'iOS & Android', 'Native UI/UX', 'API Integrations'],
+          cta: 'Learn more'
+        },
+        {
+          title: 'UI/UX Design',
+          description:
+            'Intuitive interfaces and memorable experiences that delight users and drive measurable results.',
+          features: ['Design Systems', 'Prototyping', 'Usability Testing', 'Digital Branding'],
+          cta: 'Learn more'
+        },
+        {
+          title: 'Backend Development',
+          description:
+            'Robust, scalable APIs and infrastructure that keep your applications secure, reliable, and future-proof.',
+          features: ['Node.js & Python', 'RESTful APIs', 'Databases', 'Cloud Deployments'],
+          cta: 'Learn more'
+        },
+        {
+          title: 'Optimization & Performance',
+          description:
+            'We maximize the speed and efficiency of your products. Every millisecond matters for an outstanding experience.',
+          features: ['Core Web Vitals', 'Lazy Loading', 'Caching Strategy', 'CDN Setup'],
+          cta: 'Learn more'
+        },
+        {
+          title: 'Security & Maintenance',
+          description:
+            'We protect your applications and keep everything running smoothly with continuous support and updates.',
+          features: ['SSL & HTTPS', 'Automated Backups', '24/7 Monitoring', 'Technical Support'],
+          cta: 'Learn more'
+        }
+      ],
+      bottomCta: {
+        title: 'Ready to kick off your project?',
+        description: 'Get in touch and discover how we can turn your idea into a high-impact digital product.',
+        button: 'Request a Quote'
+      }
+    },
+    portfolio: {
+      badge: 'Our Portfolio',
+      headingLine1: 'Projects that',
+      headingHighlight: 'Make a Difference',
+      description:
+        'Every project is a chance to create something extraordinary. Explore a selection of our recent work.',
+      filters: [
+        { id: 'all', label: 'All Projects' },
+        { id: 'web', label: 'Websites' },
+        { id: 'mobile', label: 'Mobile Apps' }
+      ],
+      projects: [
+        {
+          title: 'Fashion E-commerce',
+          description: 'Complete e-commerce platform with integrated payments and an intuitive admin dashboard.',
+          type: 'Website',
+          status: 'done'
+        },
+        {
+          title: 'Food Delivery App',
+          description: 'Delivery app with geolocation, online payments, and real-time customer reviews.',
+          type: 'Mobile App',
+          status: 'done'
+        },
+        {
+          title: 'Analytics Dashboard',
+          description: 'Real-time data visualization dashboard with customizable reports and KPIs.',
+          type: 'Web App',
+          status: 'done'
+        },
+        {
+          title: 'Fitness Tracker App',
+          description: 'Fitness companion with wearable integration, personalized plans, and progress tracking.',
+          type: 'Mobile App',
+          status: 'inProgress'
+        },
+        {
+          title: 'Education Portal',
+          description: 'Online learning portal with video classes, interactive exercises, and certification.',
+          type: 'Website',
+          status: 'done'
+        },
+        {
+          title: 'Digital Banking App',
+          description: 'Banking experience with biometric authentication, transfers, and investment tools.',
+          type: 'Mobile App',
+          status: 'inProgress'
+        }
+      ],
+      statusLabel: {
+        done: 'Completed',
+        inProgress: 'In progress'
+      },
+      projectCta: 'See details',
+      bottomCta: {
+        title: 'Like what you see?',
+        description:
+          'These are just a few of our projects. Let’s build something extraordinary for your company as well.',
+        button: 'Let’s Talk'
+      }
+    },
+    about: {
+      badge: 'About Us',
+      headingLine1: 'Who we are and',
+      headingHighlight: 'Our Mission',
+      description:
+        'We are a team of technology enthusiasts dedicated to turning ideas into digital products that truly matter.',
+      timelineHeading: 'Building digital experiences since 2019',
+      paragraphs: [
+        'TG Apps was born from a passion for crafting digital solutions that make a difference. We started as a small team of developers and designers and are now a trusted web and mobile development studio.',
+        'Our journey is defined by relentless technical excellence and client satisfaction. We believe technology should simplify people’s lives and drive business growth.',
+        'Every project is an opportunity to learn, innovate, and exceed expectations. We use agile methodologies, maintain transparent communication, and keep our focus on results.'
+      ],
+      missionHeading: 'Our Mission',
+      missionDescription:
+        '“Democratize access to high-quality technology by creating digital solutions that connect people, empower businesses, and bring ideas to life.”',
+      valuesHeading: 'Our Values',
+      values: [
+        {
+          title: 'Customer Focus',
+          description: 'Every project is tailored to the customer’s specific needs and business goals.'
+        },
+        {
+          title: 'Continuous Innovation',
+          description: 'We constantly embrace new technologies and best practices to deliver cutting-edge solutions.'
+        },
+        {
+          title: 'Premium Quality',
+          description: 'We never compromise on quality. Every line of code is crafted with care and attention.'
+        },
+        {
+          title: 'Measurable Results',
+          description: 'We build solutions that deliver tangible impact and measurable growth for your business.'
+        }
+      ],
+      statsHeading: 'Numbers that speak for themselves',
+      stats: [
+        { number: '100+', label: 'Projects Delivered' },
+        { number: '50+', label: 'Happy Clients' },
+        { number: '5+', label: 'Years of Experience' },
+        { number: '99%', label: 'Satisfaction Rate' }
+      ],
+      passionTitle: 'Passion for what we do',
+      passionDescription: 'Every project is developed with dedication, creativity, and care.'
+    },
+    contact: {
+      badge: 'Talk to Us',
+      headingLine1: 'Let’s turn',
+      headingHighlight: 'Your Idea into Reality',
+      description:
+        'We are ready to listen to your goals and create the ideal digital solution for your business. Reach out today!',
+      infoHeading: 'How to reach us',
+      info: [
+        { title: 'Email', value: 'support@tgapps.dev', description: 'Replies within 2 hours' },
+        { title: 'Phone', value: '+55 (11) 99999-9999', description: 'Mon-Fri, 9am to 6pm' },
+        { title: 'Location', value: 'São Paulo, Brazil', description: 'Remote service' }
+      ],
+      whyUsHeading: 'Why choose TG Apps?',
+      whyUs: [
+        'Fast replies within 2 hours',
+        'Free, no-obligation estimates',
+        'Specialized technical consulting',
+        'Ongoing support after launch'
+      ],
+      formHeading: 'Request your quote',
+      formDescription: 'Fill out the form below and we will get back to you soon.',
+      successTitle: 'Message sent successfully!',
+      successMessage: 'We will contact you shortly. Thank you!',
+      form: {
+        nameLabel: 'Full name *',
+        namePlaceholder: 'Your full name',
+        emailLabel: 'Email *',
+        emailPlaceholder: 'you@email.com',
+        phoneLabel: 'Phone',
+        phonePlaceholder: '(11) 99999-9999',
+        serviceLabel: 'Service type *',
+        servicePlaceholder: 'Select a service',
+        budgetLabel: 'Estimated budget',
+        budgetPlaceholder: 'Select a range',
+        messageLabel: 'Describe your project *',
+        messagePlaceholder: 'Tell us about your project, goals, and expectations...',
+        submit: 'Send Message',
+        submitting: 'Sending...',
+        policy: 'By submitting this form you agree to our privacy policy and terms of use.'
+      },
+      services: [
+        'Web Development',
+        'Mobile App',
+        'UI/UX Design',
+        'E-commerce',
+        'Custom System',
+        'Technical Consulting',
+        'Other'
+      ],
+      budgets: [
+        'BRL 5,000 - BRL 15,000',
+        'BRL 15,000 - BRL 30,000',
+        'BRL 30,000 - BRL 50,000',
+        'BRL 50,000 - BRL 100,000',
+        'Above BRL 100,000',
+        'Prefer not to say'
+      ]
+    },
+    footer: {
+      description:
+        'We turn ideas into outstanding digital products. Specialists in web and mobile development with a user-first mindset.',
+      navigationHeading: 'Navigation',
+      navigation: [
+        { id: 'inicio', label: 'Home' },
+        { id: 'servicos', label: 'Services' },
+        { id: 'portfolio', label: 'Portfolio' },
+        { id: 'sobre', label: 'About Us' },
+        { id: 'contato', label: 'Contact' }
+      ],
+      servicesHeading: 'Services',
+      services: [
+        'Web Development',
+        'Mobile Apps',
+        'UI/UX Design',
+        'E-commerce',
+        'Custom Systems',
+        'Technical Consulting'
+      ],
+      contactHeading: 'Contact',
+      contact: {
+        emailLabel: 'support@tgapps.dev',
+        phoneLabel: '+55 (11) 99999-9999',
+        location: 'São Paulo, Brazil'
+      },
+      cta: 'Request a Quote',
+      bottom: {
+        copyright: '© {year} TG Apps. All rights reserved.',
+        privacy: 'Privacy Policy',
+        terms: 'Terms of Use'
+      }
+    }
+  },
+  pt: {
+    header: {
+      navItems: [
+        { id: 'inicio', label: 'Início' },
+        { id: 'servicos', label: 'Serviços' },
+        { id: 'portfolio', label: 'Portfólio' },
+        { id: 'sobre', label: 'Sobre' },
+        { id: 'contato', label: 'Contato' }
+      ],
+      contactCta: 'Fale Conosco',
+      contactId: 'contato',
+      languageLabel: 'Idioma'
+    },
+    hero: {
+      badge: 'Especialistas em Produtos Digitais',
+      titleLine1: 'Transformamos',
+      titleHighlight: 'Ideias em Realidade',
+      titleLine2: 'Digital',
+      subtitle:
+        'Criamos sites modernos e aplicativos mobile que impulsionam seu negócio para o próximo nível e encantam seus clientes.',
+      stats: [
+        { label: '100+ Clientes' },
+        { label: '200+ Projetos' },
+        { label: '5 Anos de Experiência' }
+      ],
+      primaryCta: 'Começar Projeto',
+      secondaryCta: 'Ver Portfólio'
+    },
+    services: {
+      badge: 'Nossos Serviços',
+      headingLine1: 'Soluções completas para',
+      headingHighlight: 'Seu Sucesso Digital',
+      description:
+        'Oferecemos um ecossistema completo de serviços digitais, do conceito inicial ao lançamento e evolução contínua.',
+      items: [
+        {
+          title: 'Desenvolvimento Web',
+          description:
+            'Sites modernos, responsivos e focados em conversão, utilizando as tecnologias mais recentes e práticas de performance.',
+          features: ['React & Next.js', 'Design Responsivo', 'SEO Otimizado', 'Performance Máxima'],
+          cta: 'Saiba mais'
+        },
+        {
+          title: 'Apps Mobile',
+          description:
+            'Aplicativos nativos e híbridos para iOS e Android que conectam sua marca aos usuários em qualquer lugar.',
+          features: ['React Native', 'iOS & Android', 'UI/UX Nativo', 'Integração de APIs'],
+          cta: 'Saiba mais'
+        },
+        {
+          title: 'UI/UX Design',
+          description:
+            'Interfaces intuitivas e experiências memoráveis que encantam usuários e geram resultados mensuráveis.',
+          features: ['Design System', 'Prototipagem', 'Testes de Usabilidade', 'Branding Digital'],
+          cta: 'Saiba mais'
+        },
+        {
+          title: 'Desenvolvimento Backend',
+          description:
+            'APIs robustas e escaláveis que garantem segurança, confiabilidade e futuro para suas aplicações.',
+          features: ['Node.js & Python', 'APIs RESTful', 'Banco de Dados', 'Deploy em Nuvem'],
+          cta: 'Saiba mais'
+        },
+        {
+          title: 'Otimização & Performance',
+          description:
+            'Maximizamos a velocidade e eficiência dos seus produtos. Cada milissegundo conta para uma experiência incrível.',
+          features: ['Core Web Vitals', 'Lazy Loading', 'Estratégia de Cache', 'Configuração de CDN'],
+          cta: 'Saiba mais'
+        },
+        {
+          title: 'Segurança & Manutenção',
+          description:
+            'Protegemos suas aplicações e mantemos tudo funcionando perfeitamente com suporte contínuo e atualizações.',
+          features: ['SSL & HTTPS', 'Backup Automático', 'Monitoramento 24/7', 'Suporte Técnico'],
+          cta: 'Saiba mais'
+        }
+      ],
+      bottomCta: {
+        title: 'Pronto para começar seu projeto?',
+        description: 'Entre em contato e descubra como podemos transformar sua ideia em um produto digital de alto impacto.',
+        button: 'Solicitar Orçamento'
+      }
+    },
+    portfolio: {
+      badge: 'Nosso Portfólio',
+      headingLine1: 'Projetos que',
+      headingHighlight: 'Fazem a Diferença',
+      description:
+        'Cada projeto é uma oportunidade de criar algo extraordinário. Explore alguns dos nossos trabalhos mais recentes.',
+      filters: [
+        { id: 'all', label: 'Todos os Projetos' },
+        { id: 'web', label: 'Websites' },
+        { id: 'mobile', label: 'Apps Mobile' }
+      ],
+      projects: [
+        {
+          title: 'E-commerce Fashion',
+          description: 'Plataforma completa de e-commerce com pagamentos integrados e painel administrativo intuitivo.',
+          type: 'Website',
+          status: 'done'
+        },
+        {
+          title: 'App Delivery Food',
+          description: 'Aplicativo de delivery com geolocalização, pagamentos online e avaliações em tempo real.',
+          type: 'Mobile App',
+          status: 'done'
+        },
+        {
+          title: 'Dashboard Analytics',
+          description: 'Painel de controle com visualização de dados em tempo real e relatórios personalizados.',
+          type: 'Web App',
+          status: 'done'
+        },
+        {
+          title: 'App Fitness Tracker',
+          description: 'Companheiro fitness com integração de wearables, planos personalizados e acompanhamento de evolução.',
+          type: 'Mobile App',
+          status: 'inProgress'
+        },
+        {
+          title: 'Portal Educacional',
+          description: 'Plataforma de ensino online com videoaulas, exercícios interativos e certificação.',
+          type: 'Website',
+          status: 'done'
+        },
+        {
+          title: 'App Banking',
+          description: 'Experiência bancária com autenticação biométrica, transferências e ferramentas de investimento.',
+          type: 'Mobile App',
+          status: 'inProgress'
+        }
+      ],
+      statusLabel: {
+        done: 'Concluído',
+        inProgress: 'Em desenvolvimento'
+      },
+      projectCta: 'Ver detalhes',
+      bottomCta: {
+        title: 'Gostou do que viu?',
+        description:
+          'Estes são apenas alguns exemplos do nosso trabalho. Vamos criar algo incrível para a sua empresa também.',
+        button: 'Vamos Conversar'
+      }
+    },
+    about: {
+      badge: 'Sobre Nós',
+      headingLine1: 'Quem Somos e',
+      headingHighlight: 'Nossa Missão',
+      description:
+        'Somos uma equipe apaixonada por tecnologia, dedicada a transformar ideias em soluções digitais que fazem a diferença.',
+      timelineHeading: 'Transformando o digital desde 2019',
+      paragraphs: [
+        'A TG Apps nasceu da paixão por criar soluções digitais que realmente importam. Começamos como uma pequena equipe de desenvolvedores e designers, e hoje somos um estúdio de desenvolvimento web e mobile reconhecido.',
+        'Nossa jornada é marcada pela busca constante da excelência técnica e pela satisfação dos clientes. Acreditamos que a tecnologia deve simplificar a vida das pessoas e impulsionar negócios.',
+        'Cada projeto é uma oportunidade de aprender, inovar e superar expectativas. Trabalhamos com metodologias ágeis, comunicação transparente e foco total em resultados.'
+      ],
+      missionHeading: 'Nossa Missão',
+      missionDescription:
+        '“Democratizar o acesso à tecnologia de qualidade, criando soluções digitais que conectam pessoas, impulsionam negócios e transformam ideias em realidade.”',
+      valuesHeading: 'Nossos Valores',
+      values: [
+        {
+          title: 'Foco no Cliente',
+          description: 'Cada projeto é desenvolvido pensando nas necessidades específicas do cliente e seus objetivos de negócio.'
+        },
+        {
+          title: 'Inovação Constante',
+          description: 'Estamos sempre em busca de novas tecnologias e melhores práticas para entregar soluções de ponta.'
+        },
+        {
+          title: 'Qualidade Premium',
+          description: 'Não fazemos concessões quando se trata de qualidade. Cada linha de código é cuidadosamente elaborada.'
+        },
+        {
+          title: 'Resultados Mensuráveis',
+          description: 'Desenvolvemos soluções que geram impacto real e resultados tangíveis para o seu negócio.'
+        }
+      ],
+      statsHeading: 'Números que Falam por Si',
+      stats: [
+        { number: '100+', label: 'Projetos Entregues' },
+        { number: '50+', label: 'Clientes Satisfeitos' },
+        { number: '5+', label: 'Anos de Experiência' },
+        { number: '99%', label: 'Taxa de Satisfação' }
+      ],
+      passionTitle: 'Paixão pelo que fazemos',
+      passionDescription: 'Cada projeto é desenvolvido com dedicação, criatividade e carinho.'
+    },
+    contact: {
+      badge: 'Fale Conosco',
+      headingLine1: 'Vamos Transformar',
+      headingHighlight: 'Sua Ideia em Realidade',
+      description:
+        'Estamos prontos para ouvir seus objetivos e criar a solução digital ideal para o seu negócio. Fale com a gente!',
+      infoHeading: 'Como nos encontrar',
+      info: [
+        { title: 'Email', value: 'support@tgapps.dev', description: 'Resposta em até 2 horas' },
+        { title: 'Telefone', value: '+55 (11) 99999-9999', description: 'Seg-Sex, 9h às 18h' },
+        { title: 'Localização', value: 'São Paulo, SP', description: 'Atendimento remoto' }
+      ],
+      whyUsHeading: 'Por que escolher a TG Apps?',
+      whyUs: [
+        'Resposta rápida em até 2 horas',
+        'Orçamento gratuito e sem compromisso',
+        'Consultoria técnica especializada',
+        'Suporte contínuo após a entrega'
+      ],
+      formHeading: 'Solicite seu orçamento',
+      formDescription: 'Preencha o formulário abaixo e retornaremos em breve.',
+      successTitle: 'Mensagem enviada com sucesso!',
+      successMessage: 'Entraremos em contato em breve. Obrigado!',
+      form: {
+        nameLabel: 'Nome completo *',
+        namePlaceholder: 'Seu nome completo',
+        emailLabel: 'Email *',
+        emailPlaceholder: 'seu@email.com',
+        phoneLabel: 'Telefone',
+        phonePlaceholder: '(11) 99999-9999',
+        serviceLabel: 'Tipo de serviço *',
+        servicePlaceholder: 'Selecione um serviço',
+        budgetLabel: 'Orçamento estimado',
+        budgetPlaceholder: 'Selecione uma faixa',
+        messageLabel: 'Descreva seu projeto *',
+        messagePlaceholder: 'Conte-nos mais sobre seu projeto, objetivos e expectativas...',
+        submit: 'Enviar Mensagem',
+        submitting: 'Enviando...',
+        policy: 'Ao enviar este formulário, você concorda com nossa política de privacidade e termos de uso.'
+      },
+      services: [
+        'Desenvolvimento Web',
+        'Aplicativo Mobile',
+        'UI/UX Design',
+        'E-commerce',
+        'Sistema Personalizado',
+        'Consultoria Técnica',
+        'Outro'
+      ],
+      budgets: [
+        'R$ 5.000 - R$ 15.000',
+        'R$ 15.000 - R$ 30.000',
+        'R$ 30.000 - R$ 50.000',
+        'R$ 50.000 - R$ 100.000',
+        'Acima de R$ 100.000',
+        'Prefiro não informar'
+      ]
+    },
+    footer: {
+      description:
+        'Transformamos ideias em produtos digitais extraordinários. Especialistas em desenvolvimento web e mobile com foco no usuário.',
+      navigationHeading: 'Navegação',
+      navigation: [
+        { id: 'inicio', label: 'Início' },
+        { id: 'servicos', label: 'Serviços' },
+        { id: 'portfolio', label: 'Portfólio' },
+        { id: 'sobre', label: 'Sobre Nós' },
+        { id: 'contato', label: 'Contato' }
+      ],
+      servicesHeading: 'Serviços',
+      services: [
+        'Desenvolvimento Web',
+        'Apps Mobile',
+        'UI/UX Design',
+        'E-commerce',
+        'Sistemas Personalizados',
+        'Consultoria Técnica'
+      ],
+      contactHeading: 'Contato',
+      contact: {
+        emailLabel: 'support@tgapps.dev',
+        phoneLabel: '+55 (11) 99999-9999',
+        location: 'São Paulo, SP'
+      },
+      cta: 'Solicitar Orçamento',
+      bottom: {
+        copyright: '© {year} TG Apps. Todos os direitos reservados.',
+        privacy: 'Política de Privacidade',
+        terms: 'Termos de Uso'
+      }
+    }
+  }
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { LanguageProvider } from './context/LanguageContext.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <LanguageProvider>
+      <App />
+    </LanguageProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add a language context and translation tables to drive bilingual content across the site
- update all marketing sections to use localized copy with English default and Portuguese fallback
- add a flag-based language switcher in the header that toggles text across the page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de936504e0833281b5ef465b118b8f